### PR TITLE
Changing the Hash syntax for backward compatibility with 1.8.x

### DIFF
--- a/lib/xmlenc.rb
+++ b/lib/xmlenc.rb
@@ -7,8 +7,8 @@ require 'nokogiri'
 
 module Xmlenc
   NAMESPACES = {
-      xenc: 'http://www.w3.org/2001/04/xmlenc#',
-      ds:   'http://www.w3.org/2000/09/xmldsig#'
+      :xenc => 'http://www.w3.org/2001/04/xmlenc#',
+      :ds =>   'http://www.w3.org/2000/09/xmldsig#'
   }
 
   class UnsupportedError < StandardError

--- a/lib/xmlenc/builder/cipher_data.rb
+++ b/lib/xmlenc/builder/cipher_data.rb
@@ -8,7 +8,7 @@ module Xmlenc
       register_namespace "xenc", Xmlenc::NAMESPACES[:xenc]
       namespace "xenc"
 
-      element :cipher_value, String, namespace: "xenc", tag: "CipherValue"
+      element :cipher_value, String, :namespace => "xenc", :tag => "CipherValue"
     end
   end
 end

--- a/lib/xmlenc/builder/complex_types/encrypted_type.rb
+++ b/lib/xmlenc/builder/complex_types/encrypted_type.rb
@@ -8,11 +8,11 @@ module Xmlenc
         included do
           register_namespace "xenc", Xmlenc::NAMESPACES[:xenc]
 
-          has_one :encryption_method, Xmlenc::Builder::EncryptionMethod, xpath: "./"
-          has_one :key_info, Xmlenc::Builder::KeyInfo, xpath: "./"
-          has_one :cipher_data, Xmlenc::Builder::CipherData, xpath: "./"
+          has_one :encryption_method, Xmlenc::Builder::EncryptionMethod, :xpath => "./"
+          has_one :key_info, Xmlenc::Builder::KeyInfo, :xpath => "./"
+          has_one :cipher_data, Xmlenc::Builder::CipherData, :xpath => "./"
 
-          validates :cipher_data, presence: true
+          validates :cipher_data, :presence => true
         end
 
         def initialize(attributes = {})

--- a/lib/xmlenc/builder/data_reference.rb
+++ b/lib/xmlenc/builder/data_reference.rb
@@ -8,7 +8,7 @@ module Xmlenc
       register_namespace "xenc", Xmlenc::NAMESPACES[:xenc]
       namespace "xenc"
 
-      attribute :uri, String, tag: "URI"
+      attribute :uri, String, :tag => "URI"
     end
   end
 end

--- a/lib/xmlenc/builder/digest_method.rb
+++ b/lib/xmlenc/builder/digest_method.rb
@@ -8,9 +8,9 @@ module Xmlenc
       register_namespace "ds", Xmlenc::NAMESPACES[:ds]
       namespace "ds"
 
-      attribute :algorithm, String, tag: "Algorithm"
+      attribute :algorithm, String, :tag => "Algorithm"
 
-      validates :algorithm, presence: true
+      validates :algorithm, :presence => true
     end
   end
 end

--- a/lib/xmlenc/builder/encrypted_data.rb
+++ b/lib/xmlenc/builder/encrypted_data.rb
@@ -16,8 +16,8 @@ module Xmlenc
       tag "EncryptedData"
       namespace "xenc"
 
-      attribute :id, String, tag: "Id"
-      attribute :type, String, tag: "Type"
+      attribute :id, String, :tag => "Id"
+      attribute :type, String, :tag => "Type"
 
       def type
         'http://www.w3.org/2001/04/xmlenc#Element'
@@ -30,10 +30,10 @@ module Xmlenc
 
       def encrypt(data)
         encryptor = algorithm.setup
-        encrypted = encryptor.encrypt(data, node: encryption_method)
+        encrypted = encryptor.encrypt(data, :node => encryption_method)
         cipher_data.cipher_value = Base64.encode64(encrypted)
 
-        encrypted_key = EncryptedKey.new(data: encryptor.key)
+        encrypted_key = EncryptedKey.new(:data => encryptor.key)
         encrypted_key.add_data_reference(id)
         encrypted_key
       end

--- a/lib/xmlenc/builder/encrypted_key.rb
+++ b/lib/xmlenc/builder/encrypted_key.rb
@@ -11,7 +11,7 @@ module Xmlenc
       tag "EncryptedKey"
       namespace "xenc"
 
-      has_one :reference_list, Xmlenc::Builder::ReferenceList, xpath: "./"
+      has_one :reference_list, Xmlenc::Builder::ReferenceList, :xpath => "./"
 
       attr_accessor :data
 

--- a/lib/xmlenc/builder/encryption_method.rb
+++ b/lib/xmlenc/builder/encryption_method.rb
@@ -8,14 +8,14 @@ module Xmlenc
       register_namespace "xenc", Xmlenc::NAMESPACES[:xenc]
       namespace "xenc"
 
-      attribute :algorithm, String, tag: "Algorithm"
+      attribute :algorithm, String, :tag => "Algorithm"
       has_one :digest_method, Xmlenc::Builder::DigestMethod
 
-      validates :algorithm, presence: true
+      validates :algorithm, :presence => true
 
       def initialize(attributes = {})
         digest_method_algorithm = attributes.delete(:digest_method_algorithm)
-        attributes[:digest_method] = Xmlenc::Builder::DigestMethod.new(algorithm: digest_method_algorithm)
+        attributes[:digest_method] = Xmlenc::Builder::DigestMethod.new(:algorithm => digest_method_algorithm)
         super
       end
     end

--- a/lib/xmlenc/builder/key_info.rb
+++ b/lib/xmlenc/builder/key_info.rb
@@ -8,9 +8,9 @@ module Xmlenc
       register_namespace "ds", Xmlenc::NAMESPACES[:ds]
       namespace "ds"
 
-      element :key_name, String, namespace: "ds", tag: "KeyName"
+      element :key_name, String, :namespace => "ds", :tag => "KeyName"
 
-      has_one :encrypted_key, Xmlenc::Builder::EncryptedKey, xpath: "./"
+      has_one :encrypted_key, Xmlenc::Builder::EncryptedKey, :xpath => "./"
     end
   end
 end

--- a/lib/xmlenc/builder/reference_list.rb
+++ b/lib/xmlenc/builder/reference_list.rb
@@ -8,11 +8,11 @@ module Xmlenc
       register_namespace "xenc", Xmlenc::NAMESPACES[:xenc]
       namespace "xenc"
 
-      has_many :data_references, Xmlenc::Builder::DataReference, xpath: "./"
+      has_many :data_references, Xmlenc::Builder::DataReference, :xpath => "./"
 
       def add_data_reference(data_id)
         self.data_references ||= []
-        self.data_references << DataReference.new(uri: "##{data_id}")
+        self.data_references << DataReference.new(:uri => "##{data_id}")
       end
     end
   end

--- a/lib/xmlenc/encrypted_data.rb
+++ b/lib/xmlenc/encrypted_data.rb
@@ -35,14 +35,14 @@ module Xmlenc
 
     def decrypt(key)
       decryptor = algorithm.setup(key)
-      decrypted = decryptor.decrypt(Base64.decode64(cipher_value), node: encryption_method)
+      decrypted = decryptor.decrypt(Base64.decode64(cipher_value), :node => encryption_method)
       @node.replace(decrypted) unless @node == document.root
       decrypted
     end
 
     def encrypt(data)
       encryptor = algorithm.setup
-      encrypted = encryptor.encrypt(data, node: encryption_method)
+      encrypted = encryptor.encrypt(data, :node => encryption_method)
       self.cipher_value = Base64.encode64(encrypted)
       encryptor.key
     end

--- a/lib/xmlenc/encrypted_key.rb
+++ b/lib/xmlenc/encrypted_key.rb
@@ -31,12 +31,12 @@ module Xmlenc
 
     def decrypt(key)
       decryptor = algorithm.new(key)
-      decryptor.decrypt(Base64.decode64(cipher_value), node: encryption_method)
+      decryptor.decrypt(Base64.decode64(cipher_value), :node => encryption_method)
     end
 
     def encrypt(key, data)
       encryptor = algorithm.new(key)
-      encrypted = encryptor.encrypt(data, node: encryption_method)
+      encrypted = encryptor.encrypt(data, :node => encryption_method)
       self.cipher_value = Base64.encode64(encrypted)
     end
 

--- a/spec/lib/xmlenc/builder/base_spec.rb
+++ b/spec/lib/xmlenc/builder/base_spec.rb
@@ -9,7 +9,7 @@ end
 describe BaseDummy do
   describe "parse override" do
     it "sets the from_xml flag" do
-      BaseDummy.parse("<tag></tag>", single: true).from_xml?.should be_true
+      BaseDummy.parse("<tag></tag>", :single => true).from_xml?.should be_true
     end
 
     it "raises an error if the message cannot be parsed" do

--- a/spec/lib/xmlenc/builder/complex_types/encrypted_type_spec.rb
+++ b/spec/lib/xmlenc/builder/complex_types/encrypted_type_spec.rb
@@ -9,7 +9,7 @@ end
 describe Xmlenc::Builder::ComplexTypes::EncryptedType do
 
   let(:xml) { File.read File.join("spec", "fixtures", "encrypted_document.xml") }
-  subject   { EncryptedTypeDummy.new.parse(xml, single: true) }
+  subject   { EncryptedTypeDummy.new.parse(xml, :single => true) }
 
   describe "required fields" do
     it "should have the cipher data field" do

--- a/spec/lib/xmlenc/builder/data_reference_spec.rb
+++ b/spec/lib/xmlenc/builder/data_reference_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe Xmlenc::Builder::DataReference do
 
   let(:xml) { File.read File.join("spec", "fixtures", "template2.xml") }
-  subject { described_class.parse(xml, single: true) }
+  subject { described_class.parse(xml, :single => true) }
 
   describe "#parse" do
     it "should have uri attribute" do

--- a/spec/lib/xmlenc/builder/digest_method_spec.rb
+++ b/spec/lib/xmlenc/builder/digest_method_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe Xmlenc::Builder::DigestMethod do
 
   let(:xml) { File.read File.join("spec", "fixtures", "template2.xml") }
-  subject { described_class.parse(xml, single: true) }
+  subject { described_class.parse(xml, :single => true) }
 
   describe "#parse" do
     it "should have one algorithm" do

--- a/spec/lib/xmlenc/builder/encrypted_data_spec.rb
+++ b/spec/lib/xmlenc/builder/encrypted_data_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe Xmlenc::Builder::EncryptedData do
 
   let(:xml) { File.read File.join("spec", "fixtures", "encrypted_document.xml") }
-  subject   { described_class.parse(xml, single: true) }
+  subject   { described_class.parse(xml, :single => true) }
 
   describe "required fields" do
     it "should have the cipher data field" do

--- a/spec/lib/xmlenc/builder/encrypted_key_spec.rb
+++ b/spec/lib/xmlenc/builder/encrypted_key_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe Xmlenc::Builder::EncryptedKey do
 
   let(:xml) { File.read File.join("spec", "fixtures", "encrypted_document.xml") }
-  subject   { described_class.parse(xml, single: true) }
+  subject   { described_class.parse(xml, :single => true) }
 
   describe "required fields" do
     it "should have the cipher data field" do

--- a/spec/lib/xmlenc/builder/encryption_method_spec.rb
+++ b/spec/lib/xmlenc/builder/encryption_method_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe Xmlenc::Builder::EncryptionMethod do
 
   let(:xml) { File.read File.join("spec", "fixtures", "encrypted_document.xml") }
-  subject   { described_class.parse(xml, single: true) }
+  subject   { described_class.parse(xml, :single => true) }
 
   describe "required fields" do
     it "should have the algorithm field" do

--- a/spec/lib/xmlenc/builder/reference_list_spec.rb
+++ b/spec/lib/xmlenc/builder/reference_list_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe Xmlenc::Builder::ReferenceList do
 
   let(:xml) { File.read File.join("spec", "fixtures", "template2.xml") }
-  subject { described_class.parse(xml, single: true) }
+  subject { described_class.parse(xml, :single => true) }
 
   describe "#parse" do
     it "has data" do


### PR DESCRIPTION
This merge request is to make this library backward compatible with earlier versions of Ruby especially the for REE and 1.8.x. I have used this particular library for encryption and decryption here ( https://github.com/ksinkar/ruby-saml/tree/saml_enc ). But the tests fail because xmlenc Hash syntax is not 1.8.x compatible. https://travis-ci.org/onelogin/ruby-saml/builds/51369890. Hence, this pull request. 

This PR makes sure that others can use this library in enterprise environments that are still using older versions of ruby.

@benoist, it will help a lot if you can publish these changes soon into the rubygem repositories.