### PR TITLE
Changing the gemspec to load 1.8.x compatible gems

### DIFF
--- a/xmlenc.gemspec
+++ b/xmlenc.gemspec
@@ -18,9 +18,16 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", ">= 3.0.0"
-  spec.add_dependency "activemodel", ">= 3.0.0"
-  spec.add_dependency "nokogiri", "~> 1.5"
+  if RUBY_VERSION < '1.9'
+    spec.add_dependency "activesupport", "~> 3.0.0"
+    spec.add_dependency "activemodel", "~> 3.0.0"
+    spec.add_dependency "nokogiri", "~> 1.5.10"
+  else
+    spec.add_dependency "activesupport", ">= 3.0.0"
+    spec.add_dependency "activemodel", ">= 3.0.0"
+    spec.add_runtime_dependency('nokogiri', '~> 1.6.0')
+  end
+    
   spec.add_development_dependency "nokogiri-happymapper", '~> 0.5.7'
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rspec-rails", "~> 2.14"


### PR DESCRIPTION
@benoist, your response was fast. Thank you for that. #9 

Unfortunately, I had to change the gemspec and introduce conditional dependencies for backward compatibility with 1.8.x especially for activesupport and activemodel. Please merge these changes as well. 

Apologies for troubling you with this doubling of work.