### PR TITLE
Explicitly parse XML Fragment before passing to Nokogiri replace method

### DIFF
--- a/lib/xmlenc/encrypted_data.rb
+++ b/lib/xmlenc/encrypted_data.rb
@@ -36,7 +36,7 @@ module Xmlenc
     def decrypt(key)
       decryptor = algorithm.setup(key)
       decrypted = decryptor.decrypt(Base64.decode64(cipher_value), :node => encryption_method)
-      @node.replace(decrypted) unless @node == document.root
+      @node.replace(Nokogiri::XML::DocumentFragment.parse(decrypted)) unless @node == document.root
       decrypted
     end
 


### PR DESCRIPTION
I have some code that decrypts a simple test SOAP response that was encrypted with some Java code that does WS-Security Encryption

```xml
<?xml version="1.0" encoding="UTF-8"?>
<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:v4="http://namespace/">
   <soapenv:Header/>
   <soapenv:Body>
      <v4:getDocumentTypes>Hi mom.</v4:getDocumentTypes>
   </soapenv:Body>
</soapenv:Envelope>
```

But when XMLEnc tries to replace the encrypted node with the decrypted version on Jruby, it throws an exception. It doesn't throw an exception on Ruby 2.2.2 in comparison

```
RuntimeError:
       org.w3c.dom.DOMException: NOT_SUPPORTED_ERR: The implementation does not support the requested type of object or operation.
     # nokogiri/XmlNode.java:1662:in `add_child_node'
     # ./vendor/bundle/jruby/1.9/gems/nokogiri-1.6.6.2-java/lib/nokogiri/xml/node.rb:814:in `add_child_node_and_reparent_attrs'
     # ./vendor/bundle/jruby/1.9/gems/nokogiri-1.6.6.2-java/lib/nokogiri/xml/node.rb:125:in `add_child'
     # ./vendor/bundle/jruby/1.9/gems/nokogiri-1.6.6.2-java/lib/nokogiri/xml/node.rb:405:in `parent='
     # ./vendor/bundle/jruby/1.9/gems/nokogiri-1.6.6.2-java/lib/nokogiri/xml/document_fragment.rb:25:in `initialize'
     # ./vendor/bundle/jruby/1.9/gems/nokogiri-1.6.6.2-java/lib/nokogiri/xml/node_set.rb:187:in `each'
     # ./vendor/bundle/jruby/1.9/gems/nokogiri-1.6.6.2-java/lib/nokogiri/xml/node_set.rb:186:in `each'
     # ./vendor/bundle/jruby/1.9/gems/nokogiri-1.6.6.2-java/lib/nokogiri/xml/document_fragment.rb:25:in `initialize'
     # nokogiri/XmlDocumentFragment.java:107:in `new'
     # ./vendor/bundle/jruby/1.9/gems/nokogiri-1.6.6.2-java/lib/nokogiri/xml/node.rb:355:in `fragment'
     # ./vendor/bundle/jruby/1.9/gems/nokogiri-1.6.6.2-java/lib/nokogiri/xml/node.rb:796:in `coerce'
     # ./vendor/bundle/jruby/1.9/gems/nokogiri-1.6.6.2-java/lib/nokogiri/xml/node.rb:257:in `replace'
     # ./vendor/bundle/jruby/1.9/gems/xmlenc-0.2.0/lib/xmlenc/encrypted_data.rb:39:in `decrypt'
     # ./vendor/bundle/jruby/1.9/gems/xmlenc-0.2.0/lib/xmlenc/encrypted_document.rb:21:in `decrypt'
     # ./vendor/bundle/jruby/1.9/gems/xmlenc-0.2.0/lib/xmlenc/encrypted_document.rb:18:in `decrypt'
```

After doing a bit of digging, I saw that this code passed in the decrypted string directly to `Nokogiri::XML::Element#replace`. Somehow, I think Nokogiri was confused and somehow parsing the decrypted string as HTML which threw the DOM exception on the replace. So, I changed it to explicitly parse the string as a DocumentFragment before it is passed into replace and the issue went away.