### PR TITLE
EncryptedData Id attribute is invalid

### DIFF
--- a/lib/xmlenc/builder/encrypted_data.rb
+++ b/lib/xmlenc/builder/encrypted_data.rb
@@ -28,7 +28,7 @@ module Xmlenc
         if options.key?(:id)
           self.id = options.delete(:id)
         else
-          self.id = SecureRandom.hex(5)
+          self.id = "_#{SecureRandom.hex(5)}"
         end
         super(*(args << options))
       end

--- a/lib/xmlenc/version.rb
+++ b/lib/xmlenc/version.rb
@@ -1,3 +1,3 @@
 module Xmlenc
-  VERSION = "0.6.1"
+  VERSION = "0.6.2"
 end

--- a/spec/lib/xmlenc/builder/encrypted_data_spec.rb
+++ b/spec/lib/xmlenc/builder/encrypted_data_spec.rb
@@ -73,12 +73,20 @@ describe Xmlenc::Builder::EncryptedData do
   end
 
   describe "#initialize" do
-    it 'sets a default #id' do
-      expect(described_class.new().id).to be_a String
+    context 'no id specified' do
+      it 'sets a default #id' do
+        expect(described_class.new().id).to be_a String
+      end
+
+      it 'the default #id should start with a letter or an _' do
+        expect(described_class.new.id =~ /^[a-zA-Z_]/).not_to eq nil
+      end
     end
 
-    it 'sets #id to specified id' do
-      expect(described_class.new(id: 'TEST').id).to eq 'TEST'
+    context 'id specified' do
+      it 'sets #id to specified id' do
+        expect(described_class.new(id: 'TEST').id).to eq 'TEST'
+      end
     end
   end
 


### PR DESCRIPTION
The Id attribute for an EncryptedData element can only start with a letter or an _