### PR TITLE
Allow all 1.x.y versions of Nokogiri

### DIFF
--- a/xmlenc.gemspec
+++ b/xmlenc.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
     spec.add_dependency "activesupport", ">= 3.0.0"
     spec.add_dependency "activemodel", ">= 3.0.0"
     spec.add_dependency "xmlmapper", '~> 0.6'
-    spec.add_runtime_dependency('nokogiri', '~> 1.6.0')
+    spec.add_runtime_dependency('nokogiri', '>= 1.6.0', '< 2.0.0')
   end
 
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
Last one I hope. Allow higher all 1.x.y versions from 1.6.0 for Nokogiri.