### PR TITLE
Fix OpenSSL deprecation warning

### DIFF
--- a/lib/xmlenc/algorithms/aes_cbc.rb
+++ b/lib/xmlenc/algorithms/aes_cbc.rb
@@ -51,7 +51,7 @@ module Xmlenc
       end
 
       def cipher
-        @cipher ||= OpenSSL::Cipher::Cipher.new("aes-#{@size}-cbc")
+        @cipher ||= OpenSSL::Cipher.new("aes-#{@size}-cbc")
       end
     end
   end

--- a/lib/xmlenc/algorithms/des3_cbc.rb
+++ b/lib/xmlenc/algorithms/des3_cbc.rb
@@ -34,7 +34,7 @@ module Xmlenc
       end
 
       def cipher
-        @cipher ||= OpenSSL::Cipher::Cipher.new('des-ede3-cbc')
+        @cipher ||= OpenSSL::Cipher.new('des-ede3-cbc')
       end
     end
   end

--- a/spec/lib/xmlenc/phaos_compat_spec.rb
+++ b/spec/lib/xmlenc/phaos_compat_spec.rb
@@ -14,7 +14,7 @@ describe 'Phaos compatibility tests' do
 
       key = private_key.private_decrypt(key_cipher, OpenSSL::PKey::RSA::PKCS1_OAEP_PADDING)
 
-      cipher = OpenSSL::Cipher::Cipher.new('des-ede3-cbc')
+      cipher = OpenSSL::Cipher.new('des-ede3-cbc')
       cipher.decrypt
       cipher.key = key
       cipher.iv  = data_cipher[0...cipher.iv_len]
@@ -35,7 +35,7 @@ describe 'Phaos compatibility tests' do
 
       key = private_key.private_decrypt(key_cipher, OpenSSL::PKey::RSA::PKCS1_OAEP_PADDING)
 
-      cipher = OpenSSL::Cipher::Cipher.new('aes-128-cbc')
+      cipher = OpenSSL::Cipher.new('aes-128-cbc')
       cipher.decrypt
       cipher.key = key
       cipher.iv  = data_cipher[0...cipher.iv_len]
@@ -56,7 +56,7 @@ describe 'Phaos compatibility tests' do
 
       key = private_key.private_decrypt(key_cipher)
 
-      cipher = OpenSSL::Cipher::Cipher.new('aes-128-cbc')
+      cipher = OpenSSL::Cipher.new('aes-128-cbc')
       cipher.decrypt
       cipher.key = key
       cipher.iv  = data_cipher[0...cipher.iv_len]
@@ -77,7 +77,7 @@ describe 'Phaos compatibility tests' do
 
       key = private_key.private_decrypt(key_cipher)
 
-      cipher = OpenSSL::Cipher::Cipher.new('aes-256-cbc')
+      cipher = OpenSSL::Cipher.new('aes-256-cbc')
       cipher.decrypt
       cipher.key = key
       cipher.iv  = data_cipher[0...cipher.iv_len]
@@ -98,7 +98,7 @@ describe 'Phaos compatibility tests' do
 
       key = private_key.private_decrypt(key_cipher, OpenSSL::PKey::RSA::PKCS1_OAEP_PADDING)
 
-      cipher = OpenSSL::Cipher::Cipher.new('aes-256-cbc')
+      cipher = OpenSSL::Cipher.new('aes-256-cbc')
       cipher.decrypt
       cipher.key = key
       cipher.iv  = data_cipher[0...cipher.iv_len]


### PR DESCRIPTION
`OpenSSL::Cipher::Cipher` is present only for backward compability and since Ruby 2.4 it is raising deprecation warning. `OpenSSL::Cipher` should be used instead.