### PR TITLE
Add support for AES-GCM encryption methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Data algorithms
 * http://www.w3.org/2001/04/xmlenc#tripledes-cbc
 * http://www.w3.org/2001/04/xmlenc#aes128-cbc
 * http://www.w3.org/2001/04/xmlenc#aes256-cbc
+* http://www.w3.org/2009/xmlenc11#aes128-gcm
+* http://www.w3.org/2009/xmlenc11#aes192-gcm
+* http://www.w3.org/2009/xmlenc11#aes256-gcm
 
 Key algorithms
 

--- a/lib/xmlenc.rb
+++ b/lib/xmlenc.rb
@@ -38,6 +38,7 @@ module Xmlenc
     autoload :RsaOaepMgf1p, 'xmlenc/algorithms/rsa_oaep_mgf1p'
     autoload :DES3CBC, 'xmlenc/algorithms/des3_cbc'
     autoload :AESCBC, 'xmlenc/algorithms/aes_cbc'
+    autoload :AESGCM, 'xmlenc/algorithms/aes_gcm'
   end
 
   autoload :EncryptedDocument, 'xmlenc/encrypted_document'

--- a/lib/xmlenc/algorithms/aes_gcm.rb
+++ b/lib/xmlenc/algorithms/aes_gcm.rb
@@ -1,0 +1,59 @@
+module Xmlenc
+  module Algorithms
+    class AESGCM
+      AUTH_TAG_LEN = 16
+
+      class << self
+        def [](size)
+          new(size)
+        end
+      end
+
+      def initialize(size)
+        @size = size
+      end
+
+      def setup(key = nil)
+        @cipher= nil
+        @iv    = nil
+        @key   = key || cipher.random_key
+        self
+      end
+
+      def decrypt(cipher_value, options = {})
+        cipher.decrypt
+        cipher.padding  = 0
+        cipher.key      = @key
+        cipher.iv       = cipher_value[0...iv_len]
+        cipher.auth_tag = cipher_value[-AUTH_TAG_LEN..-1]
+        cipher.update(cipher_value[iv_len..-(AUTH_TAG_LEN + 1)]) << cipher.final
+      end
+
+      def encrypt(data, options = {})
+        cipher.encrypt
+        cipher.key       = @key
+        cipher.iv        = iv
+        cipher.auth_data = ''
+        iv << (cipher.update(data) << cipher.final) << cipher.auth_tag
+      end
+
+      def key
+        @key
+      end
+
+      private
+
+      def iv
+        @iv ||= cipher.random_iv
+      end
+
+      def iv_len
+        cipher.iv_len
+      end
+
+      def cipher
+        @cipher ||= OpenSSL::Cipher.new("aes-#{@size}-gcm")
+      end
+    end
+  end
+end

--- a/lib/xmlenc/builder/encrypted_data.rb
+++ b/lib/xmlenc/builder/encrypted_data.rb
@@ -6,7 +6,10 @@ module Xmlenc
       ALGORITHMS = {
           'http://www.w3.org/2001/04/xmlenc#tripledes-cbc' => Algorithms::DES3CBC,
           'http://www.w3.org/2001/04/xmlenc#aes128-cbc'    => Algorithms::AESCBC[128],
-          'http://www.w3.org/2001/04/xmlenc#aes256-cbc'    => Algorithms::AESCBC[256]
+          'http://www.w3.org/2001/04/xmlenc#aes256-cbc'    => Algorithms::AESCBC[256],
+          'http://www.w3.org/2009/xmlenc11#aes128-gcm'     => Algorithms::AESGCM[128],
+          'http://www.w3.org/2009/xmlenc11#aes192-gcm'     => Algorithms::AESGCM[192],
+          'http://www.w3.org/2009/xmlenc11#aes256-gcm'     => Algorithms::AESGCM[256]
       }
       TYPES = {
           'http://www.w3.org/2001/04/xmlenc#Element' => :element,

--- a/lib/xmlenc/encrypted_data.rb
+++ b/lib/xmlenc/encrypted_data.rb
@@ -3,7 +3,10 @@ module Xmlenc
     ALGORITHMS = {
         'http://www.w3.org/2001/04/xmlenc#tripledes-cbc' => Algorithms::DES3CBC,
         'http://www.w3.org/2001/04/xmlenc#aes128-cbc'    => Algorithms::AESCBC[128],
-        'http://www.w3.org/2001/04/xmlenc#aes256-cbc'    => Algorithms::AESCBC[256]
+        'http://www.w3.org/2001/04/xmlenc#aes256-cbc'    => Algorithms::AESCBC[256],
+        'http://www.w3.org/2009/xmlenc11#aes128-gcm'     => Algorithms::AESGCM[128],
+        'http://www.w3.org/2009/xmlenc11#aes192-gcm'     => Algorithms::AESGCM[192],
+        'http://www.w3.org/2009/xmlenc11#aes256-gcm'     => Algorithms::AESGCM[256]
     }
 
     TYPES = {

--- a/lib/xmlenc/version.rb
+++ b/lib/xmlenc/version.rb
@@ -1,3 +1,3 @@
 module Xmlenc
-  VERSION = "0.7.1"
+  VERSION = "0.7.2"
 end

--- a/spec/lib/xmlenc/algorithms/aes_gcm_spec.rb
+++ b/spec/lib/xmlenc/algorithms/aes_gcm_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+describe Xmlenc::Algorithms::AESGCM do
+  let(:data) { "<CreditCard Currency=\"USD\" Limit=\"5,000\">\r\n    <Number>4019 2445 0277 5567</Number>\r\n    <Issuer>Bank of the Internet</Issuer>\r\n    <Expiration Time=\"04/02\"/>\r\n  </CreditCard>" }
+
+  describe 'aes128-gcm' do
+    let(:cipher_value) { Base64.decode64 "YjIkLPqklVVN1faEgndPFXgXaOlVVaL+5X8NCDkbgQsbv6D2Jo7d9NQCyMbp1MgU2myCUynzdXMKdVIaqTt14pkr+NtYD6kBFPUkTvbcMIc86L5aqoMIEeqeJCK3aYLNGcY05xxOpuHvMzh2tEoZPFLEd9WgsNGhfv+4GqKiXxMVrjeLp7Iz9dYB4XmfLnQr62m4vYsZpxzg0mkxX6miCDNplv4wVBSwMDCvAFbAoWltKd+upjwaPQDNLIp0GYfQdCr7cu6K0ep4sIc=" }
+    let(:key) { %w(1e8c108fc0521dcad99ff2daad45af64).pack('H*') }
+    let(:iv) { %w(6232242cfaa495554dd5f684).pack('H*') }
+    subject { described_class.new(128).setup(key) }
+
+    describe 'encrypt' do
+      it 'encrypts the data' do
+        allow(subject).to receive(:iv).and_return(iv)
+        expect(subject.encrypt(data)).to be == cipher_value
+      end
+    end
+
+    describe 'decrypt' do
+      it 'decrypts the cipher_value' do
+        expect(subject.decrypt(cipher_value)).to be == data
+      end
+    end
+  end
+
+  describe 'aes192-gcm' do
+    let(:cipher_value) { Base64.decode64 "YjIkLPqklVVN1faETdI41CyJetO9+vdpho9swtvre7VRd5GpkFxp3lioUUlL2URCVx24YMHOzI6ksj0jQxASXn5uvNdIUrOxtTUzzUlIKk2Jbsi6uecP/YNz7NINxz4RqcjxiH+X8IF9etWAjRt+Z2zI/5YaUsQ/kPcrfesUxaH+6aMH9XWDXNqHdCjlxxMTw/4Sj9GqGmdC73CdokggeS8dfF05TZRF4lH2kTZ/RBgS7EEwwXZVKlq6yHfe5Jv2VxHqKJ8f/OSEyiw=" }
+    let(:key) { %w(68432eb84dcb27e6cf46cc8d2cb1659484bbea7d0a8131f4).pack('H*') }
+    let(:iv) { %w(6232242cfaa495554dd5f684).pack('H*') }
+    subject { described_class.new(192).setup(key) }
+
+    describe 'encrypt' do
+      it 'encrypts the data' do
+        allow(subject).to receive(:iv).and_return(iv)
+        expect(subject.encrypt(data)).to be == cipher_value
+      end
+    end
+
+    describe 'decrypt' do
+      it 'decrypts the cipher_value' do
+        expect(subject.decrypt(cipher_value)).to be == data
+      end
+    end
+  end
+
+  describe 'aes256-gcm' do
+    let(:cipher_value) { Base64.decode64 "YjIkLPqklVVN1faEcqScF7ALyB/fb+q3+HRW17n2rUqvdO8AmI4h7wXOwj5wgeP7KBCuR6IWQK9bUeZE+EoIR+tQNXmN8CofZ6s81QbZEPMiNdRnurXz0LNaSZUL1D1ivic62TYtfgqVX+z7wesGBviRM+vHcfRQlmN5sSzBtgPF9n5u2D6mpG9fa/+I33pAFDy2FeHI1CFPzLzbvKDqnjfM7zDd0YbsNi+5czoWl7likHNplPXR1jhLxOmKPWloKQVEG8f2KHsL/ZI=" }
+    let(:key) { %w(7b655b83e4821c9302d24be876b7783b2301b06b4ff89cabe8e9809d7602f207).pack('H*') }
+    let(:iv) { %w(6232242cfaa495554dd5f684).pack('H*') }
+    subject { described_class.new(256).setup(key) }
+
+    describe 'encrypt' do
+      it 'encrypts the data' do
+        allow(subject).to receive(:iv).and_return(iv)
+        expect(subject.encrypt(data)).to be == cipher_value
+      end
+    end
+
+    describe 'decrypt' do
+      it 'decrypts the cipher_value' do
+        expect(subject.decrypt(cipher_value)).to be == data
+      end
+    end
+  end
+end

--- a/xmlenc.gemspec
+++ b/xmlenc.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
     spec.add_runtime_dependency('nokogiri', '>= 1.6.0', '< 2.0.0')
   end
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", ">= 2.0"
   spec.add_development_dependency "rspec-rails", ">= 2.14"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "coveralls"


### PR DESCRIPTION
Adds support for the following encryption methods:

* http://www.w3.org/2009/xmlenc11#aes128-gcm
* http://www.w3.org/2009/xmlenc11#aes192-gcm
* http://www.w3.org/2009/xmlenc11#aes256-gcm